### PR TITLE
Defines global semantic CSS tags in 'tailwind.css'.

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -9,7 +9,7 @@ const Footer = () => (
       </div>
       <div className="flex-1 px-3">
         <h2 className="text-lg font-semibold">Important Links</h2>
-        <ul className="mt-4 leading-loose">
+        <ul className="mt-4 leading-loose list-none">
           <li>
             <a href="../../code-of-conduct/">Code of Conduct</a>
           </li>
@@ -20,7 +20,7 @@ const Footer = () => (
       </div>
       <div className="flex-1 px-3">
         <h2 className="text-lg font-semibold">Social Media</h2>
-        <ul className="mt-4 leading-loose">
+        <ul className="mt-4 leading-loose list-none">
           <li>
             <a href="https://twitter.com/MarmaladeAI">Twitter</a>
           </li>

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -31,8 +31,24 @@ ul {
   @apply mt-0 font-semibold text-xl;
 }
 
+.cardHeading {
+  @apply mt-4;
+}
+
+/* Error when attempting to use lg:text-5xl
+   `@apply` cannot be used with lg:text-5xl because 
+   lg:text-5xl is nested inside of an at-rule (@media).
+*/
+.homeSubheading {
+  @apply text-3xl font-semibold;
+}
+
 .splitHeading {
   @apply mt-0 text-3xl font-semibold leading-tight;
+}
+
+.splitBody {
+  @apply mt-8 text-xl font-light leading-relaxed;
 }
 
 @tailwind components;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -7,12 +7,8 @@ a:hover {
   @apply text-primary-darker;
 }
 
-.body-text {
-  @apply mt-2;
-}
-
 h1 {
-  @apply mt-6 text-3xl font-semibold;
+  @apply mt-6 text-center text-3xl font-semibold;
 }
 
 h2 {
@@ -23,8 +19,20 @@ h3 {
   @apply mt-6 text-xl font-semibold;
 }
 
-.page-title {
-  @apply text-center text-3xl font-semibold;
+p {
+  @apply mt-2;
+}
+
+ul {
+  @apply list-disc list-inside;
+}
+
+.cardHeading {
+  @apply mt-0 font-semibold text-xl;
+}
+
+.splitHeading {
+  @apply mt-0 text-3xl font-semibold leading-tight;
 }
 
 @tailwind components;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -7,6 +7,26 @@ a:hover {
   @apply text-primary-darker;
 }
 
+.body-text {
+  @apply mt-2;
+}
+
+h1 {
+  @apply mt-6 text-3xl font-semibold;
+}
+
+h2 {
+  @apply mt-6 text-2xl font-semibold;
+}
+
+h3 {
+  @apply mt-6 text-xl font-semibold;
+}
+
+.page-title {
+  @apply text-center text-3xl font-semibold;
+}
+
 @tailwind components;
 
 @tailwind utilities;

--- a/src/pages/code-of-conduct.js
+++ b/src/pages/code-of-conduct.js
@@ -15,29 +15,29 @@ const Index = () => (
 
         <section className="py-20 lg:pb-20 lg:pt-24">
             <div className="px-6 mx-auto lg:w-2/3">
-                <h2 className="text-center text-3xl lg:text-5xl font-semibold">Code of Conduct</h2>
-                <h2 className="mt-6 text-lg font-semibold">Our Pledge</h2>
-                <p className="mt-2">In the interest of fostering an open and welcoming environment, we as
+                <h1>Code of Conduct</h1>
+                <h2>Our Pledge</h2>
+                <p>In the interest of fostering an open and welcoming environment, we as
                 Marmalade networking members pledge to make participation in our meetings and in our community a harassment-free experience for everyone, regardless of age, body
                 size, disability, ethnicity, sex characteristics, gender identity and expression,
                 level of experience, education, socio-economic status, nationality, personal
                 appearance, race, religion, or sexual identity and orientation.
                 </p>
 
-                <h2 className="mt-6 text-lg font-semibold">Our Standards</h2>
-                <p className="mt-2">Examples of behavior that contributes to creating a positive environment
+                <h2>Our Standards</h2>
+                <p>Examples of behavior that contributes to creating a positive environment
                 include:
                 </p>
-                <ul className="list-disc list-inside">
+                <ul>
                     <li>Using welcoming and inclusive language</li>
                     <li>Being respectful of differing viewpoints and experiences</li>
                     <li>Gracefully accepting constructive criticism</li>
                     <li>Focusing on what is best for the community</li>
                     <li>Showing empathy towards other community members</li>
                 </ul>
-                <p className="mt-2">Examples of unacceptable behavior by participants include:
+                <p>Examples of unacceptable behavior by participants include:
                 </p>
-                <ul className="list-disc list-inside">
+                <ul>
                     <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
                     <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
                     <li>Public or private harassment</li>
@@ -45,28 +45,28 @@ const Index = () => (
                     <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
                 </ul>
 
-                <h2 className="mt-6 text-lg font-semibold">Our Responsibilities</h2>
-                <p className="mt-2">Marmalade AI administrators are responsible for clarifying the standards of acceptable
+                <h2>Our Responsibilities</h2>
+                <p>Marmalade AI administrators are responsible for clarifying the standards of acceptable
                 behavior and are expected to take appropriate and fair corrective action in
                 response to any instances of unacceptable behavior.
                 </p>
-                <p className="mt-2">Administrators have the right and responsibility to remove, edit, or
+                <p>Administrators have the right and responsibility to remove, edit, or
                 reject comments and other written contributions
                 that are not aligned to this Code of Conduct, or to ban temporarily or
                 permanently any networking member for other behaviors that they deem inappropriate,
                 threatening, offensive, or harmful.
                 </p>
 
-                <h2 className="mt-6 text-lg font-semibold">Scope</h2>
-                <p className="mt-2">This Code of Conduct applies within all networking spaces, and it also applies when
+                <h2>Scope</h2>
+                <p>This Code of Conduct applies within all networking spaces, and it also applies when
                 an individual is representing the community in public spaces.
                 Examples of representing the community include discussion of member experiences
                 at public social media sites. Representation of
                 the community may be further defined and clarified by Administrators.
                 </p>
 
-                <h2 className="mt-6 text-lg font-semibold">Enforcement</h2>
-                <p className="mt-2">Instances of abusive, harassing, or otherwise unacceptable behavior may be
+                <h2>Enforcement</h2>
+                <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be
                 reported by contacting the community administrators at community-administrators@marmalade.ai. All
                 complaints will be reviewed and investigated and will result in a response that
                 is deemed necessary and appropriate to the circumstances. The community administrators are
@@ -77,8 +77,8 @@ const Index = () => (
                 members of the community’s leadership.
                 </p>
 
-                <h2 className="mt-6 text-lg font-semibold">Attribution</h2>
-                <p className="mt-2">This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+                <h2>Attribution</h2>
+                <p>This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
                 available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a>. 
                 For answers to common questions about that code of conduct, see
                 <a href="https://www.contributor-cov/faq">https://www.contributor-cov/faq</a>.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,14 +32,14 @@ const Index = () => (
     </section>
     <section className="py-20 lg:pb-20 lg:pt-24">
       <div className="container mx-auto text-center">
-        <h2 className="text-3xl lg:text-5xl font-semibold">Why Choose Marmalade?</h2>
+        <h2 className="homeSubheading">Why Choose Marmalade?</h2>
 
         <SplitSection
           reverseOrder
           primarySlot={
             <div className="lg:pl-32 xl:pl-48">
-              <h3 className="splitHeadingt">Improved Networking</h3>
-              <p className="mt-8 text-xl font-light leading-relaxed">
+              <h3 className="splitHeading">Improved Networking</h3>
+              <p className="splitBody">
                 Once the market analysis process is completed our staff will search for
                 opportunities that are in reach
               </p>
@@ -57,7 +57,7 @@ const Index = () => (
           primarySlot={
             <div className="lg:pr-32 xl:pr-48">
               <h3 className="splitHeading">Automated Matching</h3>
-              <p className="mt-8 text-xl font-light leading-relaxed">
+              <p className="splitBody">
                 With all the information in place you will be presented with an action plan that
                 your company needs to follow
               </p>
@@ -76,7 +76,7 @@ const Index = () => (
           primarySlot={
             <div className="lg:pl-32 xl:pl-48">
               <h3 className="splitHeading">Serendipity Chats</h3>
-              <p className="mt-8 text-xl font-light leading-relaxed">
+              <p className="splitBody">
                 Once the market analysis process is completed our staff will search for
                 opportunities that are in reach
               </p>
@@ -94,12 +94,12 @@ const Index = () => (
     </section>
     <section id="benefits" className="py-20 lg:pb-20 lg:pt-24">
       <div className="container mx-auto text-center">
-        <h2 className="text-3xl lg:text-5xl font-semibold">Get Started with Marmalade AI</h2>
+        <h2 className="homeSubheading">Get Started with Marmalade AI</h2>
         <div className="flex flex-col sm:flex-row sm:-mx-3 mt-12">
           <div className="flex-1 px-3">
             <Card className="mb-8">
               <h3 className="cardHeading">Collaborate</h3>
-              <p className="mt-4">
+              <p className="cardBody">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
               </p>
@@ -108,7 +108,7 @@ const Index = () => (
           <div className="flex-1 px-3">
             <Card className="mb-8">
               <h3 className="cardHeading">Mentor</h3>
-              <p className="mt-4">
+              <p className="cardBody">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
               </p>
@@ -117,7 +117,7 @@ const Index = () => (
           <div className="flex-1 px-3">
             <Card className="mb-8">
               <h3 className="cardHeading">Find a Gig</h3>
-              <p className="mt-4">
+              <p className="cardBody">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
               </p>
@@ -126,7 +126,7 @@ const Index = () => (
           <div className="flex-1 px-3">
             <Card className="mb-8">
               <h3 className="cardHeading">Learn Something New</h3>
-              <p className="mt-4">
+              <p className="cardBody">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
               </p>
@@ -141,7 +141,7 @@ const Index = () => (
 
     <section id="pricing" className="py-20 lg:pb-20 lg:pt-24">
       <div className="container mx-auto text-center">
-        <h2 className="text-3xl lg:text-5xl font-semibold">Choosing a Plan</h2>
+        <h2 className="homeSubheading">Choosing a Plan</h2>
         <div className="flex flex-col">
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8 mt-12">
             <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
@@ -250,7 +250,7 @@ const Index = () => (
       </div>
     </section>
 
-    <section id="stats" className="py-20 lg:pt-32">
+    {/* <section id="stats" className="py-20 lg:pt-32">
       <div className="container mx-auto text-center">
         <LabelText className="text-gray-600">Our customers get results</LabelText>
         <div className="flex flex-col sm:flex-row mt-8 lg:px-24">
@@ -286,7 +286,7 @@ const Index = () => (
       <p className="mt-8">
         <Button size="xl">Get Started Now</Button>
       </p>
-    </section>
+    </section> */}
   </Layout>
 );
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,6 @@ import SplitSection from '../components/SplitSection';
 import StatsBox from '../components/StatsBox';
 import customerData from '../data/customer-data';
 import HeroImage from '../svg/HeroImage';
-import SvgCharts from '../svg/SvgCharts';
 import { StaticImage } from 'gatsby-plugin-image';
 
 const Index = () => (
@@ -16,7 +15,7 @@ const Index = () => (
     <section className="pt-20 md:pt-40">
       <div className="container mx-auto px-8 lg:flex">
         <div className="text-center lg:text-left lg:w-2/3">
-          <h1 className="text-4xl lg:text-5xl xl:text-6xl font-bold leading-none">
+          <h1 className="text-4xl lg:text-left lg:text-5xl xl:text-6xl font-bold leading-none">
             Connecting with peers. Made easy.
           </h1>
           <p className="text-xl lg:text-2xl mt-6 font-light">
@@ -39,7 +38,7 @@ const Index = () => (
           reverseOrder
           primarySlot={
             <div className="lg:pl-32 xl:pl-48">
-              <h3 className="text-3xl font-semibold leading-tight">Improved Networking</h3>
+              <h3 className="splitHeadingt">Improved Networking</h3>
               <p className="mt-8 text-xl font-light leading-relaxed">
                 Once the market analysis process is completed our staff will search for
                 opportunities that are in reach
@@ -57,7 +56,7 @@ const Index = () => (
         <SplitSection
           primarySlot={
             <div className="lg:pr-32 xl:pr-48">
-              <h3 className="text-3xl font-semibold leading-tight">Automated Matching</h3>
+              <h3 className="splitHeading">Automated Matching</h3>
               <p className="mt-8 text-xl font-light leading-relaxed">
                 With all the information in place you will be presented with an action plan that
                 your company needs to follow
@@ -76,7 +75,7 @@ const Index = () => (
           reverseOrder
           primarySlot={
             <div className="lg:pl-32 xl:pl-48">
-              <h3 className="text-3xl font-semibold leading-tight">Serendipity Chats</h3>
+              <h3 className="splitHeading">Serendipity Chats</h3>
               <p className="mt-8 text-xl font-light leading-relaxed">
                 Once the market analysis process is completed our staff will search for
                 opportunities that are in reach
@@ -99,7 +98,7 @@ const Index = () => (
         <div className="flex flex-col sm:flex-row sm:-mx-3 mt-12">
           <div className="flex-1 px-3">
             <Card className="mb-8">
-              <p className="font-semibold text-xl">Improved Networking</p>
+              <h3 className="cardHeading">Collaborate</h3>
               <p className="mt-4">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
@@ -108,7 +107,7 @@ const Index = () => (
           </div>
           <div className="flex-1 px-3">
             <Card className="mb-8">
-              <p className="font-semibold text-xl">Automated Matching</p>
+              <h3 className="cardHeading">Mentor</h3>
               <p className="mt-4">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
@@ -117,7 +116,7 @@ const Index = () => (
           </div>
           <div className="flex-1 px-3">
             <Card className="mb-8">
-              <p className="font-semibold text-xl">Serendipity Chats</p>
+              <h3 className="cardHeading">Find a Gig</h3>
               <p className="mt-4">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.
@@ -126,7 +125,7 @@ const Index = () => (
           </div>
           <div className="flex-1 px-3">
             <Card className="mb-8">
-              <p className="font-semibold text-xl">Serendipity Chats</p>
+              <h3 className="cardHeading">Learn Something New</h3>
               <p className="mt-4">
                 An enim nullam tempor gravida donec enim ipsum blandit porta justo integer odio
                 velna vitae auctor integer.

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -11,7 +11,7 @@ const Index = () => (
           Marmalade AI, Inc. has created this Privacy Notice to explain why we collect particular
           information and how we will protect your personal privacy when you visit our websites, or
           otherwise engage with Marmalade AI (e.g., web browsing, online chatting, and online
-          messaging) including through our comapany website and the Marmalade AI web application.
+          messaging) including through our company website and the Marmalade AI web application.
         </p>
         <p className="body-text">
           The following discloses our information collection, use, storage and other data processing
@@ -21,7 +21,7 @@ const Index = () => (
         <p className="body-text">
           Personal information is any information that personally identifies you or from which you
           could be identified. This may include your name, physical address, telephone number, email
-          address, social security number or other numerical identifier and IP address.
+          address, social security number or other numerical identifier, and IP address.
         </p>
         <p className="body-text">
           Marmalade AI may collect your personal information through your access and use of

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -1,155 +1,144 @@
 import React from 'react';
-import Button from '../components/Button';
-import Card from '../components/Card';
-import CustomerCard from '../components/CustomerCard';
-import LabelText from '../components/LabelText';
 import Layout from '../components/layout/Layout';
-import SplitSection from '../components/SplitSection';
-import StatsBox from '../components/StatsBox';
-import customerData from '../data/customer-data';
-import HeroImage from '../svg/HeroImage';
-import SvgCharts from '../svg/SvgCharts';
 
 const Index = () => (
-    <Layout>
-        <section className="py-20 lg:pb-20 lg:pt-24">
-            <div className="px-6 mx-auto lg:w-2/3">
-                <h1 className="text-center text-3xl lg:text-5xl font-semibold">Privacy Policy</h1>
-                <p className="mt-2">Last Updated: July 8, 2021</p>
-                <p className="mt-2">
-                    Marmalade AI, Inc. has created this Privacy Notice to explain why we collect particular
-                    information and how we will protect your personal privacy when you visit our websites, or
-                    otherwise engage with Marmalade AI (e.g., web browsing, online chatting, and online
-                    messaging) including through our comapany website and the Marmalade AI web application.
-                </p>
-                <p className="mt-2">
-                    The following discloses our information collection, use, storage and other data processing
-                    practices for Marmalade AI.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Collection of Personal Information</h2>
-                <p className="mt-2">
-                    Personal information is any information that personally identifies you or from which you
-                    could be identified. This may include your name, physical address, telephone number, email
-                    address, social security number or other numerical identifier and IP address.
-                </p>
-                <p className="mt-2">
-                    Marmalade AI may collect your personal information through your access and use of
-                    websites, web-based applications, or mobile applications, during conversations or
-                    correspondence with Marmalade AI representatives, or when you complete an online
-                    application or inquiry form.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">
-                    We us various technologies to collect information
-                </h2>
-                <h3 className="mt-6 text-xl font-semibold">Cookies</h3>
-                <p className="mt-2">
-                    The Marmalade AI website uses cookies. Cookies are text files that are stored in a
-                    computer system via an Internet browser.
-                </p>
-                <h3 className="mt-6 text-xl font-semibold">Internet Protocol Address</h3>
-                <p className="mt-2">
-                    We collect an IP address from all visitors to our site. An IP address is a number that is
-                    automatically assigned to your computer when you use the Internet. We use IP addresses to
-                    help diagnose problems with our server, administer our site, analyze trends, gather broad
-                    demographic information for aggregate use in order for us to improve the site, and deliver
-                    customized, personalized content. In some case we may use your IP address to customize
-                    content based on your location.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Third Parties</h2>
-                <p className="mt-2">We may disclose your information to third parties as follows:</p>
+  <Layout>
+    <section className="py-20 lg:pb-20 lg:pt-24">
+      <div className="px-6 mx-auto lg:w-2/3">
+        <div className="page-title">Privacy Policy</div>
+        <p className="body-text">Last Updated: July 8, 2021</p>
+        <p className="body-text">
+          Marmalade AI, Inc. has created this Privacy Notice to explain why we collect particular
+          information and how we will protect your personal privacy when you visit our websites, or
+          otherwise engage with Marmalade AI (e.g., web browsing, online chatting, and online
+          messaging) including through our comapany website and the Marmalade AI web application.
+        </p>
+        <p className="body-text">
+          The following discloses our information collection, use, storage and other data processing
+          practices for Marmalade AI.
+        </p>
+        <h2>Collection of Personal Information</h2>
+        <p className="body-text">
+          Personal information is any information that personally identifies you or from which you
+          could be identified. This may include your name, physical address, telephone number, email
+          address, social security number or other numerical identifier and IP address.
+        </p>
+        <p className="body-text">
+          Marmalade AI may collect your personal information through your access and use of
+          websites, web-based applications, or mobile applications, during conversations or
+          correspondence with Marmalade AI representatives, or when you complete an online
+          application or inquiry form.
+        </p>
+        <h2>We us various technologies to collect information</h2>
+        <h3>Cookies</h3>
+        <p className="body-text">
+          The Marmalade AI website uses cookies. Cookies are text files that are stored in a
+          computer system via an Internet browser.
+        </p>
+        <h3>Internet Protocol Address</h3>
+        <p className="body-text">
+          We collect an IP address from all visitors to our site. An IP address is a number that is
+          automatically assigned to your computer when you use the Internet. We use IP addresses to
+          help diagnose problems with our server, administer our site, analyze trends, gather broad
+          demographic information for aggregate use in order for us to improve the site, and deliver
+          customized, personalized content. In some case we may use your IP address to customize
+          content based on your location.
+        </p>
+        <h2>Third Parties</h2>
+        <p className="body-text">We may disclose your information to third parties as follows:</p>
 
-                <h3 className="mt-6 text-xl font-semibold">Third-Party Service Providers and Partners</h3>
-                <p className="mt-2">
-                    At times Chicago Booth will use third parties to process your information on our behalf,
-                    for example to provide services, analysis, research and development, optimization and
-                    other internal purposes, including, without limitation, to compile usage data.
-                </p>
-                <h3 className="mt-6 text-xl font-semibold">Required by Law</h3>
-                <p className="mt-2">
-                    We may share your information with third parties to the extent we are required to do so by
-                    law, court order, or subpoena.
-                </p>
-                <h3 className="mt-6 text-xl font-semibold">Consent</h3>
-                <p className="mt-2">
-                    We may seek your consent to disclose your information to third parties if we are required
-                    to do so. Where we have sought, and you have provided, your express consent for a
-                    particular purpose, please note you have the right to withdraw your consent at any time by
-                    notifying us at the contact information below.
-                </p>
-                <h3 className="mt-6 text-xl font-semibold">De-Identified and Aggregate Information</h3>
-                <p className="mt-2">
-                    We may use and disclose information about our applicants in de-identified or aggregate
-                    form without limitation.
-                </p>
-                <h3 className="mt-6 text-xl font-semibold">International Transfers</h3>
-                <p className="mt-2">
-                    We may transfer your information to third parties located in other countries. These
-                    transfers are made subject to appropriate technical safeguards and contractual provisions
-                    to ensure the security of your information.
-                </p>
-                <p className="mt-2">
-                    Occasionally, we may contract with a third party to communicate on our behalf to the
-                    third-party's contacts. We don’t collect the email addresses or contact information from
-                    these third parties, and we don’t have access to their mailing lists.
-                </p>
-                <p className="mt-2">
-                    We may provide third party mailers with a suppression list of contacts to exclude from
-                    their email distribution list. In this situation, the third party doesn’t have permission
-                    to keep or market to contacts contained in these suppression lists, or to use them in any
-                    way other than as a suppression list for a mailing they are providing on our behalf.
-                </p>
-                <p className="mt-2">
-                    Other than as described above, we will not share your personal information with any third
-                    parties.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Children's Privacy</h2>
+        <h3>Third-Party Service Providers and Partners</h3>
+        <p className="body-text">
+          At times Chicago Booth will use third parties to process your information on our behalf,
+          for example to provide services, analysis, research and development, optimization and
+          other internal purposes, including, without limitation, to compile usage data.
+        </p>
+        <h3>Required by Law</h3>
+        <p className="body-text">
+          We may share your information with third parties to the extent we are required to do so by
+          law, court order, or subpoena.
+        </p>
+        <h3>Consent</h3>
+        <p className="body-text">
+          We may seek your consent to disclose your information to third parties if we are required
+          to do so. Where we have sought, and you have provided, your express consent for a
+          particular purpose, please note you have the right to withdraw your consent at any time by
+          notifying us at the contact information below.
+        </p>
+        <h3>De-Identified and Aggregate Information</h3>
+        <p className="body-text">
+          We may use and disclose information about our applicants in de-identified or aggregate
+          form without limitation.
+        </p>
+        <h3>International Transfers</h3>
+        <p className="body-text">
+          We may transfer your information to third parties located in other countries. These
+          transfers are made subject to appropriate technical safeguards and contractual provisions
+          to ensure the security of your information.
+        </p>
+        <p className="body-text">
+          Occasionally, we may contract with a third party to communicate on our behalf to the
+          third-party's contacts. We don’t collect the email addresses or contact information from
+          these third parties, and we don’t have access to their mailing lists.
+        </p>
+        <p className="body-text">
+          We may provide third party mailers with a suppression list of contacts to exclude from
+          their email distribution list. In this situation, the third party doesn’t have permission
+          to keep or market to contacts contained in these suppression lists, or to use them in any
+          way other than as a suppression list for a mailing they are providing on our behalf.
+        </p>
+        <p className="body-text">
+          Other than as described above, we will not share your personal information with any third
+          parties.
+        </p>
 
-                <p className="mt-2">
-                    Marmalade AI does not knowingly collect information from children as defined by local law,
-                    and does not target its websites or mobile applications to children under these ages. We
-                    encourage parents and guardians to take an active role in their children’s online and
-                    mobile activities and interests.
-                </p>
+        <h2>Children's Privacy</h2>
 
-                <h2 className="mt-6 text-2xl font-semibold">Data Retention</h2>
+        <p className="body-text">
+          Marmalade AI does not knowingly collect information from children as defined by local law,
+          and does not target its websites or mobile applications to children under these ages. We
+          encourage parents and guardians to take an active role in their children’s online and
+          mobile activities and interests.
+        </p>
 
-                <p className="mt-2">
-                    The need to retain data varies depending on the type of data. Marmalade AI will retain
-                    your personal data as long as necessary for the purpose of processing (e.g., archival,
-                    data analysis). We may also retain and use your information in order to comply with our
-                    legal obligations, resolve disputes, prevent abuse, and enforce our agreements.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Security</h2>
+        <h2>Data Retention</h2>
 
-                <p className="mt-2">
-                    Marmalade AI takes seriously the trust you place in us. All information provided to
-                    Marmalade AI is transmitted using SSL (Secure Socket Layer) encryption. SSL is a proven
-                    coding system that allows your browser to automatically encrypt, or scramble, data before
-                    you send it to us. To prevent unauthorized access or disclosure, to maintain data
-                    accuracy, and to ensure the appropriate use of the information, Marmalade AI utilizes
-                    reasonable and appropriate technical and administrative procedures to safeguard the
-                    information we collect and process. We protect account information by placing it on a
-                    secure portion of our website that is only accessible by certain qualified employees of
-                    Marmalade AI. Unfortunately, however, no data transmission over the internet is 100
-                    percent secure. While we strive to protect your information, we cannot ensure or warrant
-                    the security of such information. We strongly advise you not to share your password with
-                    anyone.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Changes to the Privacy Notice</h2>
-                <p>
-                    Changes may be made to this Privacy Notice and personal information may be used for new
-                    purposes. When significant changes are made to our privacy practices, they will be
-                    disclosed here. For your convenience please refer to the last updated date.
-                </p>
-                <h2 className="mt-6 text-2xl font-semibold">Contact Information</h2>
-                <p>
-                    If you have any questions about this Privacy Notice, the practices of this site, or your dealings with this site, 
-                    you can send email to <em>privacy@marmalade.ai</em>.
-                </p>
+        <p className="body-text">
+          The need to retain data varies depending on the type of data. Marmalade AI will retain
+          your personal data as long as necessary for the purpose of processing (e.g., archival,
+          data analysis). We may also retain and use your information in order to comply with our
+          legal obligations, resolve disputes, prevent abuse, and enforce our agreements.
+        </p>
+        <h2>Security</h2>
 
-            </div>
-        </section>
-    </Layout>
+        <p className="body-text">
+          Marmalade AI takes seriously the trust you place in us. All information provided to
+          Marmalade AI is transmitted using SSL (Secure Socket Layer) encryption. SSL is a proven
+          coding system that allows your browser to automatically encrypt, or scramble, data before
+          you send it to us. To prevent unauthorized access or disclosure, to maintain data
+          accuracy, and to ensure the appropriate use of the information, Marmalade AI utilizes
+          reasonable and appropriate technical and administrative procedures to safeguard the
+          information we collect and process. We protect account information by placing it on a
+          secure portion of our website that is only accessible by certain qualified employees of
+          Marmalade AI. Unfortunately, however, no data transmission over the internet is 100
+          percent secure. While we strive to protect your information, we cannot ensure or warrant
+          the security of such information. We strongly advise you not to share your password with
+          anyone.
+        </p>
+        <h2>Changes to the Privacy Notice</h2>
+        <p className="body-text">
+          Changes may be made to this Privacy Notice and personal information may be used for new
+          purposes. When significant changes are made to our privacy practices, they will be
+          disclosed here. For your convenience please refer to the last updated date.
+        </p>
+        <h2>Contact Information</h2>
+        <p className="body-text">
+          If you have any questions about this Privacy Notice, the practices of this site, or your
+          dealings with this site, you can send email to <em>privacy@marmalade.ai</em>.
+        </p>
+      </div>
+    </section>
+  </Layout>
 );
 
 export default Index;

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -49,7 +49,7 @@ const Index = () => (
 
         <h3>Third-Party Service Providers and Partners</h3>
         <p className="body-text">
-          At times Chicago Booth will use third parties to process your information on our behalf,
+          At times Marmalade ai will use third parties to process your information on our behalf,
           for example to provide services, analysis, research and development, optimization and
           other internal purposes, including, without limitation, to compile usage data.
         </p>

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -5,25 +5,25 @@ const Index = () => (
   <Layout>
     <section className="py-20 lg:pb-20 lg:pt-24">
       <div className="px-6 mx-auto lg:w-2/3">
-        <div className="page-title">Privacy Policy</div>
-        <p className="body-text">Last Updated: July 8, 2021</p>
-        <p className="body-text">
+        <h1>Privacy Policy</h1>
+        <p>Last Updated: July 8, 2021</p>
+        <p>
           Marmalade AI, Inc. has created this Privacy Notice to explain why we collect particular
           information and how we will protect your personal privacy when you visit our websites, or
           otherwise engage with Marmalade AI (e.g., web browsing, online chatting, and online
           messaging) including through our company website and the Marmalade AI web application.
         </p>
-        <p className="body-text">
+        <p>
           The following discloses our information collection, use, storage and other data processing
           practices for Marmalade AI.
         </p>
         <h2>Collection of Personal Information</h2>
-        <p className="body-text">
+        <p>
           Personal information is any information that personally identifies you or from which you
           could be identified. This may include your name, physical address, telephone number, email
           address, social security number or other numerical identifier, and IP address.
         </p>
-        <p className="body-text">
+        <p>
           Marmalade AI may collect your personal information through your access and use of
           websites, web-based applications, or mobile applications, during conversations or
           correspondence with Marmalade AI representatives, or when you complete an online
@@ -31,12 +31,12 @@ const Index = () => (
         </p>
         <h2>We us various technologies to collect information</h2>
         <h3>Cookies</h3>
-        <p className="body-text">
+        <p>
           The Marmalade AI website uses cookies. Cookies are text files that are stored in a
           computer system via an Internet browser.
         </p>
         <h3>Internet Protocol Address</h3>
-        <p className="body-text">
+        <p>
           We collect an IP address from all visitors to our site. An IP address is a number that is
           automatically assigned to your computer when you use the Internet. We use IP addresses to
           help diagnose problems with our server, administer our site, analyze trends, gather broad
@@ -45,56 +45,56 @@ const Index = () => (
           content based on your location.
         </p>
         <h2>Third Parties</h2>
-        <p className="body-text">We may disclose your information to third parties as follows:</p>
+        <p>We may disclose your information to third parties as follows:</p>
 
         <h3>Third-Party Service Providers and Partners</h3>
-        <p className="body-text">
+        <p>
           At times Marmalade AI will use third parties to process your information on our behalf,
           for example to provide services, analysis, research and development, optimization and
           other internal purposes, including, without limitation, to compile usage data.
         </p>
         <h3>Required by Law</h3>
-        <p className="body-text">
+        <p>
           We may share your information with third parties to the extent we are required to do so by
           law, court order, or subpoena.
         </p>
         <h3>Consent</h3>
-        <p className="body-text">
+        <p>
           We may seek your consent to disclose your information to third parties if we are required
           to do so. Where we have sought, and you have provided, your express consent for a
           particular purpose, please note you have the right to withdraw your consent at any time by
           notifying us at the contact information below.
         </p>
         <h3>De-Identified and Aggregate Information</h3>
-        <p className="body-text">
+        <p>
           We may use and disclose information about our applicants in de-identified or aggregate
           form without limitation.
         </p>
         <h3>International Transfers</h3>
-        <p className="body-text">
+        <p>
           We may transfer your information to third parties located in other countries. These
           transfers are made subject to appropriate technical safeguards and contractual provisions
           to ensure the security of your information.
         </p>
-        <p className="body-text">
+        <p>
           Occasionally, we may contract with a third party to communicate on our behalf to the
           third-party's contacts. We don’t collect the email addresses or contact information from
           these third parties, and we don’t have access to their mailing lists.
         </p>
-        <p className="body-text">
+        <p>
           We may provide third party mailers with a suppression list of contacts to exclude from
           their email distribution list. In this situation, the third party doesn’t have permission
           to keep or market to contacts contained in these suppression lists, or to use them in any
           way other than as a suppression list for a mailing they are providing on our behalf.
         </p>
-        <p className="body-text">
+        <p>
           Other than as described above, we will not share your personal information with any third
           parties.
         </p>
 
         <h2>Children's Privacy</h2>
 
-        <p className="body-text">
+        <p>
           Marmalade AI does not knowingly collect information from children as defined by local law,
           and does not target its websites or mobile applications to children under these ages. We
           encourage parents and guardians to take an active role in their children’s online and
@@ -103,7 +103,7 @@ const Index = () => (
 
         <h2>Data Retention</h2>
 
-        <p className="body-text">
+        <p>
           The need to retain data varies depending on the type of data. Marmalade AI will retain
           your personal data as long as necessary for the purpose of processing (e.g., archival,
           data analysis). We may also retain and use your information in order to comply with our
@@ -111,7 +111,7 @@ const Index = () => (
         </p>
         <h2>Security</h2>
 
-        <p className="body-text">
+        <p>
           Marmalade AI takes seriously the trust you place in us. All information provided to
           Marmalade AI is transmitted using SSL (Secure Socket Layer) encryption. SSL is a proven
           coding system that allows your browser to automatically encrypt, or scramble, data before
@@ -126,13 +126,13 @@ const Index = () => (
           anyone.
         </p>
         <h2>Changes to the Privacy Notice</h2>
-        <p className="body-text">
+        <p>
           Changes may be made to this Privacy Notice and personal information may be used for new
           purposes. When significant changes are made to our privacy practices, they will be
           disclosed here. For your convenience please refer to the last updated date.
         </p>
         <h2>Contact Information</h2>
-        <p className="body-text">
+        <p>
           If you have any questions about this Privacy Notice, the practices of this site, or your
           dealings with this site, you can send email to <em>privacy@marmalade.ai</em>.
         </p>

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -49,7 +49,7 @@ const Index = () => (
 
         <h3>Third-Party Service Providers and Partners</h3>
         <p className="body-text">
-          At times Marmalade ai will use third parties to process your information on our behalf,
+          At times Marmalade AI will use third parties to process your information on our behalf,
           for example to provide services, analysis, research and development, optimization and
           other internal purposes, including, without limitation, to compile usage data.
         </p>


### PR DESCRIPTION
Proposed fix for Issue #18.

- Rather than specifying each Tailwind element in the JavaScript page files, provide global definitions for semantic elements in one file, so that any changes to one element will be applied consistently across the entire website.
- The "semantic elements" are a combination of HTML tags (`a`, `h1`, `h2`, ...) and site-specific class names (`body-text`, `page-title`, ...).