### PR TITLE
Customized 404 error page.

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,8 +3,13 @@ import Layout from '../components/layout/Layout';
 
 const NotFound = () => (
   <Layout>
-    <h1>Not Found</h1>
-    <p>You just hit a page that doesn&#39;t exist...</p>
+    <section className="py-20 lg:pb-20 lg:pt-24">
+      <div className="px-6 mx-auto lg:w-2/3 text-center">
+        <h1>404</h1>
+        <h2>Not Found</h2>
+        <p>The page you are looking for may have been moved or deleted. Try searching again.</p>
+      </div>
+    </section>
   </Layout>
 );
 


### PR DESCRIPTION
Changed from the default Gatsby implementation of the 404 "not found" page to customize the format and content.