### PR TITLE
Refactored to use semantic HTML where possible.

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -1,37 +1,44 @@
 import React from 'react';
+import { Link } from 'gatsby';
 
 const Footer = () => (
   <footer className="container mx-auto py-16 px-3 mt-48 mb-8 text-gray-800">
     <div className="flex -mx-3">
-      <div className="flex-1 px-3">
+      <section className="flex-1 px-3">
         <h2 className="text-lg font-semibold">About Us</h2>
-        <p className="mt-5">Ridiculus mus mauris vitae ultricies leo integer malesuada nunc.</p>
-      </div>
-      <div className="flex-1 px-3">
+        <p className="mt-5">
+          How freelancers connect with peers to share gigs and stay up-to-date.
+        </p>
+      </section>
+      <section className="flex-1 px-3">
         <h2 className="text-lg font-semibold">Important Links</h2>
-        <ul className="mt-4 leading-loose list-none">
-          <li>
-            <a href="../../code-of-conduct/">Code of Conduct</a>
-          </li>
-          <li>
-            <a href="../../privacy-policy/">Privacy Policy</a>
-          </li>
-        </ul>
-      </div>
-      <div className="flex-1 px-3">
+        <nav>
+          <ul className="mt-4 leading-loose list-none">
+            <li>
+              <Link to="/code-of-conduct">Code of Conduct</Link>
+            </li>
+            <li>
+              <Link to="/privacy-policy">Privacy Policy</Link>
+            </li>
+          </ul>
+        </nav>
+      </section>
+      <section className="flex-1 px-3">
         <h2 className="text-lg font-semibold">Social Media</h2>
-        <ul className="mt-4 leading-loose list-none">
-          <li>
-            <a href="https://twitter.com/MarmaladeAI">Twitter</a>
-          </li>
-          <li>
-            <a href="https://github.com/marmalade-ai">GitHub</a>
-          </li>
-          <li>
-            <a href="https://www.linkedin.com/company/marmalade-ai/about/">LinkedIn</a>
-          </li>
-        </ul>
-      </div>
+        <nav>
+          <ul className="mt-4 leading-loose list-none">
+            <li>
+              <a href="https://twitter.com/MarmaladeAI">Twitter</a>
+            </li>
+            <li>
+              <a href="https://github.com/marmalade-ai">GitHub</a>
+            </li>
+            <li>
+              <a href="https://www.linkedin.com/company/marmalade-ai">LinkedIn</a>
+            </li>
+          </ul>
+        </nav>
+      </section>
     </div>
   </footer>
 );

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,43 +1,43 @@
 import React from 'react';
-import AnchorLink from 'react-anchor-link-smooth-scroll';
 import { Link } from 'gatsby';
-import LogoIcon from '../../svg/LogoIcon';
-import Button from '../Button';
 import { StaticImage } from 'gatsby-plugin-image';
+import Button from '../Button';
 
 const Header = () => (
   <header className="sticky top-0 bg-white shadow z-50">
-    <div className="container flex flex-col sm:flex-row justify-between items-center mx-auto py-4 px-8">
+    <nav className="container flex flex-col sm:flex-row justify-between items-center mx-auto py-4 px-8">
       <div className="flex items-center text-2xl">
         <div className="w-12 mr-3">
-          <StaticImage src="../../images/marmalade-logo.jpg" alt="Marmalade AI Logo" />
+          <Link to="/#">
+            <StaticImage src="../../images/marmalade-logo.jpg" alt="Marmalade AI Logo" />
+          </Link>
         </div>
         Marmalade AI
       </div>
       <div className="flex mt-4 sm:mt-0">
-        <Link className="px-4" to="../../#">
+        <Link className="px-4" to="/#">
           Home
         </Link>
-        <Link className="px-4" to="../../#benefits">
+        <Link className="px-4" to="/#benefits">
           Features
         </Link>
-        <Link className="px-4" to="../../#pricing">
+        <Link className="px-4" to="/#pricing">
           Pricing
         </Link>
-        <Link className="px-4" to="../../#">
+        <Link className="px-4" to="/#">
           News
         </Link>
-        <Link className="px-4" to="../../#">
+        <Link className="px-4" to="/#">
           FAQ
         </Link>
-        <Link className="px-4" to="../../about/">
+        <Link className="px-4" to="/about">
           About Us
         </Link>
       </div>
       <div className="hidden md:block">
         <Button className="text-sm">Login</Button>
       </div>
-    </div>
+    </nav>
   </header>
 );
 

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1,32 +1,35 @@
 @tailwind base;
 
-a {
-  @apply text-primary;
-}
-a:hover {
-  @apply text-primary-darker;
+@layer base {
+  a {
+    @apply text-primary;
+  }
+  a:hover {
+    @apply text-primary-darker;
+  }
+
+  h1 {
+    @apply mt-6 text-center text-3xl font-semibold;
+  }
+
+  h2 {
+    @apply mt-6 text-2xl font-semibold;
+  }
+
+  h3 {
+    @apply mt-6 text-xl font-semibold;
+  }
+
+  p {
+    @apply mt-2;
+  }
+
+  ul {
+    @apply list-disc list-inside;
+  }
 }
 
-h1 {
-  @apply mt-6 text-center text-3xl font-semibold;
-}
-
-h2 {
-  @apply mt-6 text-2xl font-semibold;
-}
-
-h3 {
-  @apply mt-6 text-xl font-semibold;
-}
-
-p {
-  @apply mt-2;
-}
-
-ul {
-  @apply list-disc list-inside;
-}
-
+/** Application-specific classes **/
 .cardHeading {
   @apply mt-0 font-semibold text-xl;
 }

--- a/src/pages/code-of-conduct.js
+++ b/src/pages/code-of-conduct.js
@@ -1,92 +1,92 @@
 import React from 'react';
-import Button from '../components/Button';
-import Card from '../components/Card';
-import CustomerCard from '../components/CustomerCard';
-import LabelText from '../components/LabelText';
 import Layout from '../components/layout/Layout';
-import SplitSection from '../components/SplitSection';
-import StatsBox from '../components/StatsBox';
-import customerData from '../data/customer-data';
-import HeroImage from '../svg/HeroImage';
-import SvgCharts from '../svg/SvgCharts';
 
 const Index = () => (
-    <Layout>
+  <Layout>
+    <article className="py-20 lg:pb-20 lg:pt-24">
+      <div className="px-6 mx-auto lg:w-2/3">
+        <h1>Code of Conduct</h1>
+        <h2>Our Pledge</h2>
+        <p>
+          In the interest of fostering an open and welcoming environment, we as Marmalade networking
+          members pledge to make participation in our meetings and in our community a
+          harassment-free experience for everyone, regardless of age, body size, disability,
+          ethnicity, sex characteristics, gender identity and expression, level of experience,
+          education, socio-economic status, nationality, personal appearance, race, religion, or
+          sexual identity and orientation.
+        </p>
 
-        <section className="py-20 lg:pb-20 lg:pt-24">
-            <div className="px-6 mx-auto lg:w-2/3">
-                <h1>Code of Conduct</h1>
-                <h2>Our Pledge</h2>
-                <p>In the interest of fostering an open and welcoming environment, we as
-                Marmalade networking members pledge to make participation in our meetings and in our community a harassment-free experience for everyone, regardless of age, body
-                size, disability, ethnicity, sex characteristics, gender identity and expression,
-                level of experience, education, socio-economic status, nationality, personal
-                appearance, race, religion, or sexual identity and orientation.
-                </p>
+        <h2>Our Standards</h2>
+        <p>Examples of behavior that contributes to creating a positive environment include:</p>
+        <ul>
+          <li>Using welcoming and inclusive language</li>
+          <li>Being respectful of differing viewpoints and experiences</li>
+          <li>Gracefully accepting constructive criticism</li>
+          <li>Focusing on what is best for the community</li>
+          <li>Showing empathy towards other community members</li>
+        </ul>
+        <p>Examples of unacceptable behavior by participants include:</p>
+        <ul>
+          <li>
+            The use of sexualized language or imagery and unwelcome sexual attention or advances
+          </li>
+          <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+          <li>Public or private harassment</li>
+          <li>
+            Publishing others’ private information, such as a physical or electronic address,
+            without explicit permission
+          </li>
+          <li>
+            Other conduct which could reasonably be considered inappropriate in a professional
+            setting
+          </li>
+        </ul>
 
-                <h2>Our Standards</h2>
-                <p>Examples of behavior that contributes to creating a positive environment
-                include:
-                </p>
-                <ul>
-                    <li>Using welcoming and inclusive language</li>
-                    <li>Being respectful of differing viewpoints and experiences</li>
-                    <li>Gracefully accepting constructive criticism</li>
-                    <li>Focusing on what is best for the community</li>
-                    <li>Showing empathy towards other community members</li>
-                </ul>
-                <p>Examples of unacceptable behavior by participants include:
-                </p>
-                <ul>
-                    <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
-                    <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
-                    <li>Public or private harassment</li>
-                    <li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
-                    <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
-                </ul>
+        <h2>Our Responsibilities</h2>
+        <p>
+          Marmalade AI administrators are responsible for clarifying the standards of acceptable
+          behavior and are expected to take appropriate and fair corrective action in response to
+          any instances of unacceptable behavior.
+        </p>
+        <p>
+          Administrators have the right and responsibility to remove, edit, or reject comments and
+          other written contributions that are not aligned to this Code of Conduct, or to ban
+          temporarily or permanently any networking member for other behaviors that they deem
+          inappropriate, threatening, offensive, or harmful.
+        </p>
 
-                <h2>Our Responsibilities</h2>
-                <p>Marmalade AI administrators are responsible for clarifying the standards of acceptable
-                behavior and are expected to take appropriate and fair corrective action in
-                response to any instances of unacceptable behavior.
-                </p>
-                <p>Administrators have the right and responsibility to remove, edit, or
-                reject comments and other written contributions
-                that are not aligned to this Code of Conduct, or to ban temporarily or
-                permanently any networking member for other behaviors that they deem inappropriate,
-                threatening, offensive, or harmful.
-                </p>
+        <h2>Scope</h2>
+        <p>
+          This Code of Conduct applies within all networking spaces, and it also applies when an
+          individual is representing the community in public spaces. Examples of representing the
+          community include discussion of member experiences at public social media sites.
+          Representation of the community may be further defined and clarified by Administrators.
+        </p>
 
-                <h2>Scope</h2>
-                <p>This Code of Conduct applies within all networking spaces, and it also applies when
-                an individual is representing the community in public spaces.
-                Examples of representing the community include discussion of member experiences
-                at public social media sites. Representation of
-                the community may be further defined and clarified by Administrators.
-                </p>
+        <h2>Enforcement</h2>
+        <p>
+          Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+          contacting the community administrators at community-administrators@marmalade.ai. All
+          complaints will be reviewed and investigated and will result in a response that is deemed
+          necessary and appropriate to the circumstances. The community administrators are obligated
+          to maintain confidentiality with regard to the reporter of an incident. Further details of
+          specific enforcement policies may be posted separately. Community administrators who do
+          not follow or enforce the Code of Conduct in good faith may face temporary or permanent
+          repercussions as determined by other members of the community’s leadership.
+        </p>
 
-                <h2>Enforcement</h2>
-                <p>Instances of abusive, harassing, or otherwise unacceptable behavior may be
-                reported by contacting the community administrators at community-administrators@marmalade.ai. All
-                complaints will be reviewed and investigated and will result in a response that
-                is deemed necessary and appropriate to the circumstances. The community administrators are
-                obligated to maintain confidentiality with regard to the reporter of an incident.
-                Further details of specific enforcement policies may be posted separately.
-                Community administrators who do not follow or enforce the Code of Conduct in good
-                faith may face temporary or permanent repercussions as determined by other
-                members of the community’s leadership.
-                </p>
-
-                <h2>Attribution</h2>
-                <p>This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
-                available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a>. 
-                For answers to common questions about that code of conduct, see
-                <a href="https://www.contributor-cov/faq">https://www.contributor-cov/faq</a>.
-                </p>
-            </div>
-        </section>
-
-    </Layout>
+        <h2>Attribution</h2>
+        <p>
+          This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at{' '}
+          <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">
+            https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+          </a>
+          . For answers to common questions about that code of conduct, see&nbsp;
+          <a href="https://www.contributor-cov/faq">https://www.contributor-cov/faq</a>.
+        </p>
+      </div>
+    </article>
+  </Layout>
 );
 
 export default Index;

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -3,20 +3,23 @@ import Layout from '../components/layout/Layout';
 
 const Index = () => (
   <Layout>
-    <section className="py-20 lg:pb-20 lg:pt-24">
+    <article className="py-20 lg:pb-20 lg:pt-24">
       <div className="px-6 mx-auto lg:w-2/3">
         <h1>Privacy Policy</h1>
-        <p>Last Updated: July 8, 2021</p>
+        <p>
+          Last Updated: <time datetime="2021-07-14 11:42">July 14, 2021</time>
+        </p>
         <p>
           Marmalade AI, Inc. has created this Privacy Notice to explain why we collect particular
-          information and how we will protect your personal privacy when you visit our websites, or
+          information and how we will protect your personal privacy when you visit our websites or
           otherwise engage with Marmalade AI (e.g., web browsing, online chatting, and online
           messaging) including through our company website and the Marmalade AI web application.
         </p>
         <p>
-          The following discloses our information collection, use, storage and other data processing
-          practices for Marmalade AI.
+          The following discloses our information collection, use, storage, and other data
+          processing practices for Marmalade AI.
         </p>
+
         <h2>Collection of Personal Information</h2>
         <p>
           Personal information is any information that personally identifies you or from which you
@@ -29,6 +32,7 @@ const Index = () => (
           correspondence with Marmalade AI representatives, or when you complete an online
           application or inquiry form.
         </p>
+
         <h2>We us various technologies to collect information</h2>
         <h3>Cookies</h3>
         <p>
@@ -44,9 +48,9 @@ const Index = () => (
           customized, personalized content. In some case we may use your IP address to customize
           content based on your location.
         </p>
+
         <h2>Third Parties</h2>
         <p>We may disclose your information to third parties as follows:</p>
-
         <h3>Third-Party Service Providers and Partners</h3>
         <p>
           At times Marmalade AI will use third parties to process your information on our behalf,
@@ -63,7 +67,7 @@ const Index = () => (
           We may seek your consent to disclose your information to third parties if we are required
           to do so. Where we have sought, and you have provided, your express consent for a
           particular purpose, please note you have the right to withdraw your consent at any time by
-          notifying us at the contact information below.
+          notifying us through the contact information shown below.
         </p>
         <h3>De-Identified and Aggregate Information</h3>
         <p>
@@ -78,12 +82,12 @@ const Index = () => (
         </p>
         <p>
           Occasionally, we may contract with a third party to communicate on our behalf to the
-          third-party's contacts. We don’t collect the email addresses or contact information from
-          these third parties, and we don’t have access to their mailing lists.
+          third-party's contacts. We do not collect the email addresses or contact information from
+          these third parties, and we do not have access to their mailing lists.
         </p>
         <p>
           We may provide third party mailers with a suppression list of contacts to exclude from
-          their email distribution list. In this situation, the third party doesn’t have permission
+          their email distribution list. In this situation, the third party does not have permission
           to keep or market to contacts contained in these suppression lists, or to use them in any
           way other than as a suppression list for a mailing they are providing on our behalf.
         </p>
@@ -93,24 +97,22 @@ const Index = () => (
         </p>
 
         <h2>Children's Privacy</h2>
-
         <p>
           Marmalade AI does not knowingly collect information from children as defined by local law,
           and does not target its websites or mobile applications to children under these ages. We
-          encourage parents and guardians to take an active role in their children’s online and
+          encourage parents and guardians to take an active role in their children's online and
           mobile activities and interests.
         </p>
 
         <h2>Data Retention</h2>
-
         <p>
           The need to retain data varies depending on the type of data. Marmalade AI will retain
           your personal data as long as necessary for the purpose of processing (e.g., archival,
           data analysis). We may also retain and use your information in order to comply with our
           legal obligations, resolve disputes, prevent abuse, and enforce our agreements.
         </p>
-        <h2>Security</h2>
 
+        <h2>Security</h2>
         <p>
           Marmalade AI takes seriously the trust you place in us. All information provided to
           Marmalade AI is transmitted using SSL (Secure Socket Layer) encryption. SSL is a proven
@@ -125,19 +127,22 @@ const Index = () => (
           the security of such information. We strongly advise you not to share your password with
           anyone.
         </p>
+
         <h2>Changes to the Privacy Notice</h2>
         <p>
           Changes may be made to this Privacy Notice and personal information may be used for new
           purposes. When significant changes are made to our privacy practices, they will be
-          disclosed here. For your convenience please refer to the last updated date.
+          disclosed here. For your convenience please refer to the last updated date displayed on
+          this page.
         </p>
+
         <h2>Contact Information</h2>
         <p>
           If you have any questions about this Privacy Notice, the practices of this site, or your
-          dealings with this site, you can send email to <em>privacy@marmalade.ai</em>.
+          dealings with this site, you can send email to <i>privacy@marmalade.ai</i>.
         </p>
       </div>
-    </section>
+    </article>
   </Layout>
 );
 


### PR DESCRIPTION
Resolves Issue #22.

* Verified semantic hierarchy implied by use of `h1`, `h2`, `h3` tags.
* Made some changes from `section` to `article`, based on documentation of semantic HTML. See:
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
    * https://developers.google.com/style/semantic-tagging
* Introduced `nav` tag in a few places, as part of semantic HTML.
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
* Modified some `Link` elements to use Gatsby idiomatic reference to paths.
    * https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/