### PR TITLE
Specify 1 column for small screens.

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -7,7 +7,7 @@ const About = () => (
   <Layout>
     <section id="mission" className="lg:pb-10 lg:pt-10">
       <div className="container mx-auto">
-        <h2 className="aboutSubHeading lg:text-5xl xl:text-6xl">Our Mission</h2>
+        <h2 className="aboutSubHeading lg:text-5xl xl:text-6xl">Mission</h2>
         <div className="grid sm:flex-row sm:-mx-3 mt-6">
           <div className="flex-1 px-3">
             <h3 className="cardHeading">Make freelancing easier</h3>
@@ -51,10 +51,8 @@ const About = () => (
     </section>
     <section id="founders" className="lg:pb-10 lg:pt-10">
       <div className="container mx-auto text-center">
-        <h2 className="aboutSubHeading lg:text-5xl xl:text-6xl">
-          Our Founders
-        </h2>
-        <div className="grid grid-cols-2 sm:flex-row sm:-mx-3 mt-12">
+        <h2 className="aboutSubHeading lg:text-5xl xl:text-6xl">Founders</h2>
+        <div className="grid grid-cols-1 flex-col -mx-3 md:grid-cols-2 md:mt-12">
           <div className="flex-1 px-3">
             <Card className="mb-8">
               <StaticImage


### PR DESCRIPTION
Resolves #45.

Uses default settings for smallest size, then specifies format for screen sizes greater than or equal to a certain breakpoint. In this case, let one column be the default, e.g. for phones, then expand to two columns for medium or larger screens.

## References
* [Noel Rapin](https://noelrappin.com/). May 2021. [Modern CSS with Tailwind](https://pragprog.com/titles/tailwind/modern-css-with-tailwind/): Flexible styling without the fuss. The Pragmatic Programmers.
    * Chapter 7 "Responsive Design".
    * Section: "[Tailwind Screen Widths and Breakpoints](https://learning.oreilly.com/library/view/modern-css-with/9781680508567/f_0048.xhtml#d24e5540)"
        ```html
        In Tailwind, you can put a prefix on any Tailwind utility to specify 
        the minimum screen width where that utility should be applied.
        ```
        * Note that it is the _minimum_ screen. So default settings with no size should be specified for the smallest screen(s). Then explicitly specify a larger screen size at which the format should change, because the class will apply at that size _and larger_. So we need to design for mobile first and then specify a specific size when larger screens should look differently.
    * Section: "[Fewer Grid Columns on Small Devices](https://learning.oreilly.com/library/view/modern-css-with/9781680508567/f_0050.xhtml#d24e5741)"
        * "On a smartphone, you might want only one item across the screen; on a desktop, maybe four. So you can use something like this:"
        ```html
        <div class="grid items-stretch
            md:grid-cols-2 md:gap-4
            lg:grid-cols-4 lg:gap-4">
          <div class="mb-6 lg:mb-0"></div>
          ...
        </div>
        ```
        * "The parent div is a grid at all widths, but the default grid size at the narrowest width is 1, growing to 2 on a medium screen and to 4 on a large screen."
