### PR TITLE
Enables testing dev server from other machines on local network

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,8 +61,9 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        name: 'GatsbyJS',
-        short_name: 'GatsbyJS',
+        name: 'Marmalade.ai | Home',
+        short_name: 'Marmalade.ai',
+        description: 'Marmalade.ai | Making freelancer networking easier.',
         start_url: '/',
         background_color: '#6b37bf',
         theme_color: '#6b37bf',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,22 +2,29 @@ const tailwindcss = require('tailwindcss');
 const autoprefixer = require('autoprefixer');
 
 module.exports = {
+  flags: {
+    DEV_SSR: false,
+    FAST_DEV: false,
+    LMDB_STORE: false,
+    PARALLEL_SOURCING: false,
+    PRESERVE_FILE_DOWNLOAD_CACHE: false,
+  },
   siteMetadata: {
-    title: `Marmalade AI`,
-    description: `Marmalade AI`,
-    author: `Marmalade AI`,
+    title: 'Marmalade AI',
+    description: 'Marmalade AI',
+    author: 'Marmalade AI',
   },
   plugins: [
     {
-      resolve: "gatsby-plugin-google-tagmanager",
+      resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: "GTM-M97RDW8",
-  
+        id: 'GTM-M97RDW8',
+
         // Include GTM in development.
         //
         // Defaults to false meaning GTM will only be loaded in production.
         includeInDevelopment: true,
-  
+
         // datalayer to be set before GTM is loaded
         // should be an object or a function that is executed in the browser
         //
@@ -37,39 +44,39 @@ module.exports = {
         /*
         routeChangeEventName: "YOUR_ROUTE_CHANGE_EVENT_NAME",
         */
-       // Defaults to false
+        // Defaults to false
         enableWebVitalsTracking: true,
       },
     },
     'gatsby-plugin-image',
     'gatsby-plugin-sharp',
     'gatsby-plugin-gatsby-cloud',
-    `gatsby-plugin-react-helmet`,
+    'gatsby-plugin-react-helmet',
     {
-      resolve: `gatsby-plugin-postcss`,
+      resolve: 'gatsby-plugin-postcss',
       options: {
         postCssPlugins: [tailwindcss('./tailwind.config.js'), autoprefixer],
       },
     },
     {
-      resolve: `gatsby-plugin-manifest`,
+      resolve: 'gatsby-plugin-manifest',
       options: {
-        name: `GatsbyJS`,
-        short_name: `GatsbyJS`,
-        start_url: `/`,
-        background_color: `#6b37bf`,
-        theme_color: `#6b37bf`,
+        name: 'GatsbyJS',
+        short_name: 'GatsbyJS',
+        start_url: '/',
+        background_color: '#6b37bf',
+        theme_color: '#6b37bf',
         // Enables "Add to Homescreen" prompt and disables browser UI (including back button)
         // see https://developers.google.com/web/fundamentals/web-app-manifest/#display
-        display: `standalone`,
-        icon: `src/images/marmalade-logo-tiny.png`, // This path is relative to the root of the site.
+        display: 'standalone',
+        icon: 'src/images/marmalade-logo-tiny.png', // This path is relative to the root of the site.
       },
     },
     {
-      resolve: `gatsby-plugin-purgecss`,
+      resolve: 'gatsby-plugin-purgecss',
       options: {
         printRejected: true, // Print removed selectors and processed file names
-        develop: false, // Enable while using `gatsby develop`
+        develop: false, // Enable while using 'gatsby develop'
         tailwind: true, // Enable tailwindcss support
         whitelist: ['whitelist'], // Don't remove this selector
         ignore: ['/ignored.css', 'prismjs/', 'docsearch.js/'], // Ignore files/folders

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "version": "2.0.0",
   "license": "MIT",
   "scripts": {
-    "develop": "gatsby develop -H 0.0.0.0",
+    "develop": "gatsby develop --host 0.0.0.0",
     "build": "gatsby build",
-    "serve": "gatsby serve -H 0.0.0.0",
+    "serve": "gatsby serve --host 0.0.0.0",
     "clean": "gatsby clean",
     "info": "gatsby info",
     "lint": "npx eslint .",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.0",
   "license": "MIT",
   "scripts": {
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve -H 0.0.0.0",
     "clean": "gatsby clean",
     "info": "gatsby info",
     "lint": "npx eslint .",


### PR DESCRIPTION
* Fixes #132.
* Enables testing dev server from other machines on local network, e.g. from a phone on a local network behind a router.
* No changes to development pattern. You still start the server with `npm run develop` or `npm run serve`.
* This was a known limitation of Gatsby. See [Testing Site with Gatsby Develop from Local LAN](https://github.com/gatsbyjs/gatsby/issues/5801), which is supposed to be fixed by [Ensure publicPath is always relative for gatsby develop](https://github.com/gatsbyjs/gatsby/pull/11227).
* See the documentation, [Commands (Gatsby CLI)])https://www.gatsbyjs.com/docs/reference/gatsby-cli/), for the `--host` option for `gatsby develop`, which explains that using `--host 0.0.0.0` will make the server available on the local network.
* I made the suggested change to `package.json`, which fixed the problem for me in this environment:
    * macOS 11.5.2
    * running the dev server in `zsh` with `npm run develop`
    * Gatsby version: 3.14.0
    * Gatsby CLI version: 3.10.0