### PR TITLE
Added <Link> to apply for Early Access in the text of the FAQ.

### DIFF
--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -33,10 +33,12 @@ const Faq = () => (
 
         <h2>What do I need to do to get started?</h2>
         <p>
-          Once you have been accepted into the Early Access program, you will have a link to the app.
-          Register, login, fill in MyProfile (including &quot;About,&quot; which
-          you might cut and paste from Linkedin, About.me, or similar sources),
-          upload a photo, browse Profiles, connect with people.
+          Once you have been accepted into the Early Access program (click to
+          <Link to="/alphaGoogleForm"> Apply for Early Access</Link>), you will
+          have a link to the app. Register, login, fill in MyProfile (including
+          &quot;About,&quot; which you might cut and paste from Linkedin,
+          About.me, or similar sources), upload a photo, browse Profiles,
+          connect with people.
         </p>
 
         <h2>


### PR DESCRIPTION
Following up on another Doug Hunter suggestion: if we refer to Early Access in the FAQ, provide a link to click to apply.