### PR TITLE
Revised content of `Communities` pages

### DIFF
--- a/src/pages/code-of-conduct.js
+++ b/src/pages/code-of-conduct.js
@@ -5,11 +5,11 @@ import SEO from '../components/seo';
 const CodeOfConduct = () => (
   <Layout>
     <SEO title="Code of Conduct" description="Code of Conduct" />
-    <div className="container mx-auto mt-10">
+    <div className="px-10 mx-auto mt-10">
       <h1>Code of Conduct</h1>
     </div>
-    <article className="py-20 lg:pb-4 lg:pt-4">
-      <div className="px-6 mx-auto lg:w-2/3">
+    <article className="pt-5">
+      <div className="px-10 mx-auto">
         <h2>Our Pledge</h2>
         <p>
           In the interest of fostering an open and welcoming environment, we as

--- a/src/pages/communities/digital-marketing.js
+++ b/src/pages/communities/digital-marketing.js
@@ -12,7 +12,7 @@ const DigitalMarketing = () => (
       title="Digital Marketing"
       description="Digital Marketing community of freelancers."
     />
-    <div className="container mx-auto mt-10">
+    <div className="px-10 mx-auto mt-10">
       <h1>
         <StaticImage
           className="rounded-lg shadow-lg rounded-lg-vertical-align"

--- a/src/pages/communities/digital-marketing.js
+++ b/src/pages/communities/digital-marketing.js
@@ -64,11 +64,8 @@ const DigitalMarketing = () => (
             <Button size="lg">Apply for Early Access</Button>
           </Link>
         </p>
+        <div className="pt-10" />
         <h2>How Can I Do Better as a Freelancer in Digital Marketing?</h2>
-        <p>
-          &quot;How can you help me do <b>better</b> as a freelancer in digital
-          marketing?&quot;
-        </p>
         <p>
           If you found us through a <b>search query</b>, was it something like
           that? Or did you get results that seemed like answers to a different
@@ -83,12 +80,12 @@ const DigitalMarketing = () => (
         <h2>Virtual Network</h2>
         <p>
           The <b>short answer</b> is: sign up and use Marmalade AI's virtual
-          network that applies NLP to your profile to connect you with other
-          specialists in digital marketing. So how do you get a profile? Well,
-          you can copy and paste from elsewhere, or write it from scratch.
-          Either way, it is quick to register. Instead of taking years to build
-          up a network, a virtual network takes minutes and reflects your
-          profile.
+          network that is derived from your profile. Marmalade AI will connect
+          you with other specialists in digital marketing. So how do you get a
+          profile? Well, you can copy and paste from elsewhere, or write it from
+          scratch. Either way, it is quick to register. Instead of taking years
+          to build up a network, a virtual network takes minutes and reflects
+          your profile.
         </p>
         <p>
           The <b>long answer</b> is: by using Marmalade AI you can have a
@@ -100,8 +97,7 @@ const DigitalMarketing = () => (
           for freelancers? It is the same idea. Your virtual network reflects
           your profile. It is normally composed of other digital marketing
           freelancers with related specializations. It changes when you change
-          your profile (caveat: in &quot;Early Access,&quot; it changes the next
-          time our matching engine runs; which is not in real time currently).
+          your profile.
         </p>
         <p>
           This means you can use your virtual network to <b>find help</b> on
@@ -120,7 +116,7 @@ const DigitalMarketing = () => (
           you to focus on what you are good at.
         </p>
         <p>
-          <b>Transactions</b> are one part of the story; <b>and</b> the other is{' '}
+          <b>Transactions</b> are one part of the story; the other is{' '}
           <b>learning</b>. How do you efficiently stay current in topics that
           are important to, but not core to, your expertise? How about, for
           example, if you could create a virtual room at 12:00pm (EST){' '}
@@ -132,7 +128,7 @@ const DigitalMarketing = () => (
         <SplitSection
           reverseOrder
           primarySlot={
-            <div className="lg:pl-32 xl:pl-48">
+            <div className="pl-8">
               <p className="splitBody">
                 Digital marketing means collaboration to get feedback.
               </p>
@@ -147,24 +143,7 @@ const DigitalMarketing = () => (
             />
           }
         />
-        <SplitSection
-          primarySlot={
-            <div className="lg:pr-32 xl:pr-48">
-              <p className="splitBody">
-                Search Engine Optimization (SEO) is key to inbound marketing and
-                it is changing rapidly.
-              </p>
-            </div>
-          }
-          secondarySlot={
-            <StaticImage
-              className="rounded-lg shadow-lg	"
-              src="../../images/pexels-freeboilergrants-7119258_300.jpg"
-              alt="Scrabble tiles spelling SEO."
-              title="SEO is essential to inbound marketing."
-            />
-          }
-        />
+        <div className="pt-10" />
         <h2>Community First, Then Everything Else</h2>
         <p>
           The <b>road map is up to you</b>. The evolution of Marmalade AI is
@@ -182,26 +161,34 @@ const DigitalMarketing = () => (
           easily. How exactly that plays out in creating a platform for
           community is really up to you.
         </p>
-        <h2>About the Sign Up Form</h2>
+        <SplitSection
+          primarySlot={
+            <div className="pr-8">
+              <p className="splitBody">
+                Search Engine Optimization (SEO) is key to inbound marketing and
+                it is changing rapidly.
+              </p>
+            </div>
+          }
+          secondarySlot={
+            <StaticImage
+              className="rounded-lg shadow-lg	"
+              src="../../images/pexels-freeboilergrants-7119258_300.jpg"
+              alt="Scrabble tiles spelling SEO."
+              title="SEO is essential to inbound marketing."
+            />
+          }
+        />
+        <div className="pt-10" />
+        <h2>We Are Open To Input From The Community!</h2>
         <p>
-          In the sign-up form, we ask freelancers in digital marketing to
-          identify their <b>specializations</b>. So please indicate your focus
-          in areas such as SEO, WordPress, content, new market development,
-          website development, positioning, competitive analysis, collateral,
-          influencer marketing, branding, inbound marketing, growth, data
-          analytics, ecommerce, paid media and advertising, social media,
-          events, and customer journeys.
-        </p>
-        <h2>Please Tell Use What to Do Next!</h2>
-        <p>
-          If we missed a digital marketing specialization, please tick
-          &quot;other&quot; and let us know. More broadly, we said a little
-          about what we think is on the road map: community, co-working,
-          control. But that is subject to what we hear from you.{' '}
-          <b>Please invite people</b> you are already working with, think you
+          We said a little about what we think is on the road map: community,
+          co-working, control. But that is subject to what we hear from you.{' '}
+          <b>Please invite people</b> you are already working with or think you
           could be working with, and explore virtual networking. We are big
           believers in self-organizing communities.
         </p>
+        <div className="pt-10" />
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in digital marketing, I would like to <b>join</b> the

--- a/src/pages/communities/digital-marketing.js
+++ b/src/pages/communities/digital-marketing.js
@@ -23,8 +23,8 @@ const DigitalMarketing = () => (
         Digital Marketing
       </h1>
     </div>
-    <article className="py-20 lg:pb-4 lg:pt-4">
-      <div className="px-6 mx-auto lg:w-2/3">
+    <article className="pt-5">
+      <div className="px-10 mx-auto">
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in digital marketing, I would like to <b>join</b> the

--- a/src/pages/communities/machine-learning.js
+++ b/src/pages/communities/machine-learning.js
@@ -23,8 +23,8 @@ const MachineLearning = () => (
         Machine Learning
       </h1>
     </div>
-    <article className="py-20 lg:pb-4 lg:pt-4">
-      <div className="px-6 mx-auto lg:w-2/3">
+    <article className="pt-5">
+      <div className="px-10 mx-auto">
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in machine learning, I would like to <b>join</b> the

--- a/src/pages/communities/machine-learning.js
+++ b/src/pages/communities/machine-learning.js
@@ -12,7 +12,7 @@ const MachineLearning = () => (
       title="Machine Learning"
       description="Machine Learning community of freelancers."
     />
-    <div className="container mx-auto mt-10">
+    <div className="px-10 mx-auto mt-10">
       <h1>
         <StaticImage
           className="rounded-lg shadow-lg rounded-lg-vertical-align"

--- a/src/pages/communities/machine-learning.js
+++ b/src/pages/communities/machine-learning.js
@@ -64,11 +64,8 @@ const MachineLearning = () => (
             <Button size="lg">Apply for Early Access</Button>
           </Link>
         </p>
+        <div className="pt-10" />
         <h2>How Can I Do Better as a Freelancer in Machine Learning?</h2>
-        <p>
-          &quot;How can you help me do <b>better</b> as a freelancer in machine
-          learning?&quot;
-        </p>
         <p>
           If you found us through a <b>search query</b>, was that like the one
           you used? Did you get mostly <i>irrelevant</i> results? Results that
@@ -83,8 +80,8 @@ const MachineLearning = () => (
         <h2>Virtual Network</h2>
         <p>
           The <b>short answer</b> is: sign up and use the virtual network that
-          automatically is created by applying NLP to your profile, which you
-          can copy and paste from elsewhere, or write from scratch.
+          is created automatically from your profile, which you can copy and
+          paste from elsewhere, or write from scratch.
         </p>
         <p>
           The <b>long answer</b> is: use Marmalade AI to have a network where
@@ -95,9 +92,7 @@ const MachineLearning = () => (
         </p>
         <p>
           Your <b>virtual network</b> reflects your profile. It is specific to
-          you. Your virtual network changes when you change your profile
-          (caveat: it changes the next time our engine runs, which is not in
-          real time currently).
+          you. Your virtual network changes when you change your profile.
         </p>
         <p>
           This means you can use your virtual network to find someone to{' '}
@@ -114,12 +109,11 @@ const MachineLearning = () => (
           you to focus on what you are good at.
         </p>
         <p>
-          That is all <b>transactional</b>, <b>and</b> there are also
-          partnerships for <b>learning</b>. You need to be up-to-date in
-          peripheral expertise. Maybe you can pop up a virtual room at 3:00pm
-          (Pacific) today to discuss the latest in GPT-3 or BERT, and send
-          notifications about it just to people who have indicated an interest
-          in that topic.
+          That is all <b>transactional</b>, but there are also partnerships for{' '}
+          <b>learning</b>. You need to be up-to-date in peripheral expertise.
+          Maybe you can pop up a virtual room at 3:00pm (Pacific) today to
+          discuss the latest in GPT-3 or BERT, and send notifications about it
+          just to people who have indicated an interest in that topic.
         </p>
         <p>
           Like Quora, Reddit, Slack, Clubhouse, etc., but <b>more exact</b> and
@@ -129,7 +123,7 @@ const MachineLearning = () => (
         <SplitSection
           reverseOrder
           primarySlot={
-            <div className="lg:pl-32 xl:pl-48">
+            <div className="pl-8">
               <p className="splitBody">
                 Freelancers in machine learning are generally familiar with the
                 Python Pandas library for data preparation.
@@ -145,24 +139,7 @@ const MachineLearning = () => (
             />
           }
         />
-        <SplitSection
-          primarySlot={
-            <div className="lg:pr-32 xl:pr-48">
-              <p className="splitBody">
-                Freelancers in machine learning often create charts of time
-                series data.
-              </p>
-            </div>
-          }
-          secondarySlot={
-            <StaticImage
-              className="rounded-lg shadow-lg	"
-              src="../../images/stephen-phillips-hostreviews-co-uk-shr_Xn8S8QU-unsplash_300.jpg"
-              alt="A chart of time series data."
-              title="A chart of time series data."
-            />
-          }
-        />
+        <div className="pt-10" />
         <h2>Community First, Then Everything Else</h2>
         <p>
           The <b>road map is subject to your guidance</b>.
@@ -179,18 +156,38 @@ const MachineLearning = () => (
           and this is Early Access.
         </p>
         <p>
-          We think a core idea is using technology (NLP, virtualization) to
-          enable more <b>exact connections</b> more easily. How that plays out
-          is TBD by your feeback.
+          We think a core idea is using machine learning to enable more{' '}
+          <b>exact connections</b> more easily. How that plays out will be
+          determined by your feeback.
         </p>
-        <h2>Please Tell Use What to Do Next!</h2>
+        <SplitSection
+          primarySlot={
+            <div className="pr-8">
+              <p className="splitBody">
+                Freelancers in machine learning often create charts of time
+                series data.
+              </p>
+            </div>
+          }
+          secondarySlot={
+            <StaticImage
+              className="rounded-lg shadow-lg	"
+              src="../../images/stephen-phillips-hostreviews-co-uk-shr_Xn8S8QU-unsplash_300.jpg"
+              alt="A chart of time series data."
+              title="A chart of time series data."
+            />
+          }
+        />
+        <div className="pt-10" />
+        <h2>We Are Open To Input From The Community!</h2>
         <p>
-          If we missed a machine learning specialization, please tick
-          &quot;other&quot; and let us know. More broadly, platform evolution is
-          up to you. <b>Please invite people</b> you are already working with,
-          think you could be working with, and explore virtual networking. We
-          are big believers in self-organizing communities.
+          We said a little about what we think is on the road map: community,
+          co-working, control. But that is subject to what we hear from you.{' '}
+          <b>Please invite people</b> you are already working with or think you
+          could be working with, and explore virtual networking. We are big
+          believers in self-organizing communities.
         </p>
+        <div className="pt-10" />
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in machine learning, I would like to <b>join</b> the

--- a/src/pages/communities/ux-design.js
+++ b/src/pages/communities/ux-design.js
@@ -61,15 +61,12 @@ const UXDesign = () => (
             <Button size="lg">Apply for Early Access</Button>
           </Link>
         </p>
+        <div className="pt-10" />
         <h2>How Can I Do Better as a Freelancer in UX Design?</h2>
         <p>
-          &quot;How can you help me do <b>better</b> as a freelancer in UX
-          design?&quot;
-        </p>
-        <p>
           We hope that is the kind of <b>search query</b> that brought you to
-          us. If so, you maybe had to sort through a LOT of irrelevant results
-          that assumed you wanted to be siloed, commoditized, and
+          us. If so, you maybe had to sort through <b>many</b> irrelevant
+          results that assumed you wanted to be siloed, commoditized, and
           undifferentiated.
         </p>
         <p>
@@ -112,9 +109,8 @@ const UXDesign = () => (
           work you do.
         </p>
         <SplitSection
-          reverseOrder
           primarySlot={
-            <div className="lg:pl-32 xl:pl-48">
+            <div className="pl-8">
               <p className="splitBody">
                 UX design immerses the user in the experience.
               </p>
@@ -129,23 +125,7 @@ const UXDesign = () => (
             />
           }
         />
-        <SplitSection
-          primarySlot={
-            <div className="lg:pr-32 xl:pr-48">
-              <p className="splitBody">
-                UX designers test interactions on multiple devices.
-              </p>
-            </div>
-          }
-          secondarySlot={
-            <StaticImage
-              className="rounded-lg shadow-lg	"
-              src="../../images/taras-shypka-iFSvn82XfGo-unsplash_300.jpg"
-              alt="Tablet in front of a large computer screen."
-              title="Designing for multiple devices."
-            />
-          }
-        />
+        <div className="pt-10" />
         <h2>Community First, Then Everything Else</h2>
         <p>
           Marmalade AI&apos;s core idea is to make networking virtual. By doing
@@ -162,26 +142,33 @@ const UXDesign = () => (
           </a>{' '}
           and this is Early Access.
         </p>
-        <h2>About the Sign Up Form</h2>
+        <SplitSection
+          primarySlot={
+            <StaticImage
+              className="rounded-lg shadow-lg	"
+              src="../../images/taras-shypka-iFSvn82XfGo-unsplash_300.jpg"
+              alt="Tablet in front of a large computer screen."
+              title="Designing for multiple devices."
+            />
+          }
+          secondarySlot={
+            <div className="pr-8">
+              <p className="splitBody">
+                UX designers test interactions on multiple devices.
+              </p>
+            </div>
+          }
+        />
+        <div className="pt-10" />
+        <h2>We Are Open To Input From The Community!</h2>
         <p>
-          In the sign-up form, we ask freelancers in UX design to identify their{' '}
-          <b>specializations</b>. NLP will be the engine, once we scale up. In
-          the near term, we use simple matching. So indicate in the sign up form
-          your interest in areas such as graphic design, creative design, UX
-          design, CX, wireframing, conversational design, prototyping, A/B
-          testing, mobile, packaging, healthcare, industrial, research,
-          information architecture, UI developer, interaction design, and UX
-          writer.
+          We said a little about what we think is on the road map: community,
+          co-working, control. But that is subject to what we hear from you.{' '}
+          <b>Please invite people</b> you are already working with or think you
+          could be working with, and explore virtual networking. We are big
+          believers in self-organizing communities.
         </p>
-        <h2>Please Tell Use What to Do Next!</h2>
-        <p>
-          If we missed a UX design specialization, please tick &quot;other&quot;
-          and let us know. More broadly, we said a little about what we think is
-          on the road map: community, co-working, control. But that is subject
-          to what we hear from you. <b>Please invite people</b> you are already
-          working with, think you could be working with, and explore virtual
-          networking. We are big believers in self-organizing communities.
-        </p>
+        <div className="pt-10" />
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in UX design, I would like to <b>join</b> the free

--- a/src/pages/communities/ux-design.js
+++ b/src/pages/communities/ux-design.js
@@ -9,7 +9,7 @@ import SplitSection from '../../components/SplitSection';
 const UXDesign = () => (
   <Layout>
     <SEO title="UX Design" description="UX Design community of freelancers." />
-    <div className="container mx-auto mt-10">
+    <div className="px-10 mx-auto mt-10">
       <h1>
         <StaticImage
           className="rounded-lg shadow-lg rounded-lg-vertical-align"

--- a/src/pages/communities/ux-design.js
+++ b/src/pages/communities/ux-design.js
@@ -20,8 +20,8 @@ const UXDesign = () => (
         UX Design
       </h1>
     </div>
-    <article className="py-20 lg:pb-4 lg:pt-4">
-      <div className="px-6 mx-auto lg:w-2/3">
+    <article className="pt-5">
+      <div className="px-10 mx-auto">
         <h2>Sign up to try it!</h2>
         <p>
           As a freelancer in UX design, I would like to <b>join</b> the free

--- a/src/pages/privacy-policy.js
+++ b/src/pages/privacy-policy.js
@@ -5,11 +5,11 @@ import SEO from '../components/seo';
 const PrivacyPolicy = () => (
   <Layout>
     <SEO title="Privacy Policy" description="Privacy Policy" />
-    <div className="container mx-auto mt-10">
+    <div className="px-10 mx-auto mt-10">
       <h1>Privacy Policy</h1>
     </div>
-    <article className="py-20 lg:pb-4 lg:pt-4">
-      <div className="px-6 mx-auto lg:w-2/3">
+    <article className="pt-5">
+      <div className="px-10 mx-auto">
         <p className="mt-6 font-semibold text-xl">
           Last Updated: <time dateTime="2021-07-14 11:42">July 14, 2021</time>
         </p>


### PR DESCRIPTION
* Editing of content based on:
    * #117
    * #158
* In the niches pages, duplicated the "sign up" form at the top, cut the "Evolution" and "Deep Dive" sections, and moved the photos to the middle.
* Haven't been able to figure out:
    1. how to get rid of the excessive vertical space at the top and bottom; or
    2. how to get &lt;html5&gt; style &lt;figure&gt; and &lt;figcaption&gt; for these photos, so they drop into the text.
* Seems to be the case that Tailwind has elaborate ideas about how to layout images and haven't found anything yet that is just simple photo and caption insertion. Will do more research.